### PR TITLE
Prepare for deployment

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+.build/test
+src
+test
+.travis.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,3 @@
 language: node_js
 node_js:
-    - "0.10"
+    - "6"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tslint-language-service",
   "version": "1.0.0",
   "description": "tslint - language services",
-  "main": "lib/index.js",
+  "main": ".build/src/index.js",
   "author": "Angelo ZERR",
   "license": "MIT",
   "repository": {
@@ -10,14 +10,15 @@
     "url": "https://github.com/angelozerr/tslint-language-service.git"
   },
   "scripts": {
-    "build": "tsc --outDir lib src/*.ts",
     "test": "tsc && tape .build/test/**/*.spec.js"
   },
   "dependencies": {},
   "devDependencies": {
     "@types/node": "^7.0.8",
     "@types/tape": "^4.2.29",
-    "tape": "^4.6.3"
+    "tape": "^4.6.3",
+    "tslint": "^4.5.1",
+    "typescript": "^2.2.1"
   },
   "peerDependencies": {
     "typescript": "2.2.x",


### PR DESCRIPTION
Resolves #9 

Adds `.npmignore` so only the following files go to the deployment package:
 - `LICENSE`
 - `README`
 - `package.json`
 - `.build/src/`

I had to add typescript and tslint to devDependencies to allow the tsc compilation.

I removed the `lib` folder and left only the `.build` one, also modified the package.json to point to it. If you think lib is better we can change the output folder to lib again. We come back to a single folder for the artifacts 😄

@angelozerr If you don't have an npm account is time to create one. You can do `npm login` once you have one to create an access token, you'll have to add it to the CI to allow the deployments.

This token is added to your `~/.npmrc` file if you use linux / macosx. I'm not sure where this file is in win. 

Once you have this use the `travis-cli`: `travis setup npm` follow the steps, add the token from the previous file and it will add the deployment part of the travis.yml file. Ensure you select the encrypt option during the steps so the token is not in plain text.

To finalize ensure that you have in the deployment section  `skip_cleanup: true` and `deploy: on: tags: true`

```yml
deploy:
  ...
  on:
    tags: true
  skip_cleanup: true

```

More info:
https://docs.travis-ci.com/user/deployment/npm/