### PR TITLE
Do not ignore deployment files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 .npmignore
-scripts
-src
-test
+/scripts
+/src
+/test
+/out/test
+/out/src/*.map
+tsconfig.json
 .travis.yml
 .project


### PR DESCRIPTION
Modifies the .npmignore so the deployment files would be in the deployment package:

You can use `npm pack` to check the bundle and what is in it before publishing.