### PR TITLE
Use any ts version between 2.2 and 3 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typescript": "2.3.1-insiders.20170420"
   },
   "peerDependencies": {
-    "typescript": ">= 2.2 < 3",
+    "typescript": ">= 2.3.1 < 3",
     "tslint": ">= 4 < 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "typescript": "2.3.1-insiders.20170420"
   },
   "peerDependencies": {
-    "typescript": "2.2.x",
+    "typescript": ">= 2.2 < 3",
     "tslint": ">= 4 < 6"
   }
 }


### PR DESCRIPTION
Closes #23

If semantic versioning works the plugin shouldn't break if there's no bump in the major version of typescript. So the peer dependency should be placed from 2.2 all the way up to 3