### PR TITLE
Add support for fix all auto fixable rule failures

### DIFF
--- a/dev/tsconfig.json
+++ b/dev/tsconfig.json
@@ -10,7 +10,7 @@
             }
         ],
         "module": "commonjs",
-        "target": "es5",
+        "target": "es6",
         "allowJs": true,
         "noImplicitAny": false,
         "sourceMap": false

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
 	"compilerOptions": {
-		"target": "es5",
+		"target": "es6",
 		"module": "commonjs",
 		"inlineSourceMap": true,
 		"inlineSources": true,


### PR DESCRIPTION
- update the target to es6 (so that the spread operator can be fully used)
- add support for fixing all auto fixable errors

@angelozerr this is how far we can close the gaps between the language server plugin and vscode-tslint. See #32 for the current status. Can you please update the node module.