### PR TITLE
Force tslint to use the same typescript version as the language service

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Your `node_modules` folder should look like this:
  * `alwaysShowRuleFailuresAsWarnings` - always show rule failures as warnings, ignoring the severity configuration in the tslint.json configuration.
  * `disableNoUnusedVariableRule` - disable `no-unused-variable` rule.
  * `supressWhileTypeErrorsPresent` - supress tslint errors from being reported while other errors are present.
+ * `mockTypeScriptVersion` - force tslint to use the same version of TypeScript as this plugin. This will affect other plugins that require the typescript package.
  
 Here a configuration sample:
 
@@ -53,7 +54,8 @@ Here a configuration sample:
         "ignoreDefinitionFiles": true,
         "configFile": "../tslint.json",
         "disableNoUnusedVariableRule": false,
-        "supressWhileTypeErrorsPresent": false
+        "supressWhileTypeErrorsPresent": false,
+        "mockTypeScriptVersion": false
       }
     ]
   }

--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
     "test": "tsc && tape out/test/**/*.spec.js",
     "lint": "tslint src/index.ts"
   },
-  "dependencies": {},
+  "dependencies": {
+    "mock-require": "^2.0.2"
+  },
   "devDependencies": {
     "@types/node": "^7.0.8",
     "@types/tape": "^4.2.29",
+    "@types/mock-require": "^2.0.0",
     "tape": "^4.6.3",
     "tslint": "^5.2.0",
     "typescript": "^2.3.2",


### PR DESCRIPTION
This PR mocks `require` when loading tslint to ensure that the version of typescript it uses is the same as the version used by the language service to parse source files. 

Fixes #58

Tested in VS 2017 and VS Code. Note that using `npm run devtest` won't work by itself until the package is published, until then you'll need to `npm install mock-require` in the test project manually.