### PR TITLE
Only require tslint once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,6 @@ const TSLINT_ERROR_CODE = 100000;
 
 function init(modules: { typescript: typeof ts_module }) {
     const ts = modules.typescript;
-    let tslint = require('tslint');
 
     let codeFixActions = new Map<string, Map<string, tslint.RuleFailure>>();
     let registeredCodeFixes = false;
@@ -67,8 +66,8 @@ function init(modules: { typescript: typeof ts_module }) {
 
         if(config.mockTypeScriptVersion) {
             mockRequire('typescript', ts);
-            tslint = mockRequire.reRequire('tslint');
         }
+        const tslint = require('tslint')
 
         // Set up decorator
         const proxy = Object.create(null) as ts.LanguageService;


### PR DESCRIPTION
Fixes #65

This pushes the initial require for tslint to much later in the plugin.
When `mockTypeScriptVersion` is turned on this means we require after mocking typescript, rather than requiring once, and then reRequiring after mocking.

There's an `import * as tslint from 'tslint'` at the top of the file still, but this is currently removed on compilation.