### PR TITLE
Fixes case where endPosition === startPosition

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,7 +101,7 @@ function init(modules: { typescript: typeof ts_module }) {
             let diagnostic: ts.Diagnostic = {
                 file: file,
                 start: problem.getStartPosition().getPosition(),
-                length: problem.getEndPosition().getPosition() - problem.getStartPosition().getPosition(),
+                length: problem.getEndPosition().getPosition() - problem.getStartPosition().getPosition() || 1,
                 messageText: message,
                 category: category,
                 source: 'tslint',


### PR DESCRIPTION
Some times, when endPosition is equal to startPosition, length ends up being zero.

This makes language server (I'm using javascript-typescript-langserver) give wrong diagnostics
flagging the problem at position (0, 0).

`space-in-parens` error is an example:

```es6
    import('./test3' /* webpackChunkName: "test3" */).then(({ test3 }) => {
      test3('first');
    });
```