### PR TITLE
Support exclude

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "lint": "tslint src/index.ts"
   },
   "dependencies": {
+    "minimatch": "^3.0.4",
     "mock-require": "^2.0.2"
   },
   "devDependencies": {
+    "@types/minimatch": "^3.0.3",
     "@types/node": "^7.0.8",
     "@types/tape": "^4.2.29",
     "@types/mock-require": "^2.0.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import * as ts_module from "../node_modules/typescript/lib/tsserverlibrary";
 import * as tslint from 'tslint';
 import * as path from 'path';
 import * as mockRequire from 'mock-require';
+import * as minimatch from 'minimatch';
 
 // Settings for the plugin section in tsconfig.json
 interface Settings {
@@ -361,6 +362,11 @@ function init(modules: { typescript: typeof ts_module }) {
 
                 try {
                     configuration = getConfiguration(fileName, config.configFile);
+                    if (configuration.linterOptions &&
+                        configuration.linterOptions.exclude &&
+                        configuration.linterOptions.exclude.some(function (pattern) { return new minimatch.Minimatch(pattern).match(fileName) })) {
+                        return prior;
+                    }
                 } catch (err) {
                     // TODO: show the reason for the configuration failure to the user and not only in the log
                     // https://github.com/Microsoft/TypeScript/issues/15913

--- a/src/index.ts
+++ b/src/index.ts
@@ -412,8 +412,8 @@ function init(modules: { typescript: typeof ts_module }) {
             return prior;
         };
 
-        proxy.getCodeFixesAtPosition = function (fileName: string, start: number, end: number, errorCodes: number[], formatOptions: ts.FormatCodeSettings): ReadonlyArray<ts.CodeAction> {
-            let prior = oldLS.getCodeFixesAtPosition(fileName, start, end, errorCodes, formatOptions);
+        proxy.getCodeFixesAtPosition = function (fileName: string, start: number, end: number, errorCodes: number[], formatOptions: ts.FormatCodeSettings, preferences: ts.UserPreferences): ReadonlyArray<ts.CodeFixAction> {
+            let prior = oldLS.getCodeFixesAtPosition(fileName, start, end, errorCodes, formatOptions, preferences);
             if (config.supressWhileTypeErrorsPresent && prior.length > 0) {
                 return prior;
             }


### PR DESCRIPTION
Support the [`linterOptions.exclude` tslint configuration property](https://palantir.github.io/tslint/usage/configuration/) to ensure consistent behavior with the command line tslint.

Update the `proxy.getCodeFixesAtPosition` api while we're at it.