### PR TITLE
Upgrade peerDependencies to support TS 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "copyfiles": "^1.2.0"
   },
   "peerDependencies": {
-    "typescript": "^2.3.1 || 3",
+    "typescript": "^2.3.1 || ^3.0.0",
     "tslint": ">= 4 < 6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "copyfiles": "^1.2.0"
   },
   "peerDependencies": {
-    "typescript": ">= 2.3.1 < 3",
+    "typescript": "^2.3.1 || 3",
     "tslint": ">= 4 < 6"
   }
 }


### PR DESCRIPTION
As TS 3 was released, updating peerDependency requirement will remove the warnings shown and will show compatibility for users trying to TLS with TS 3.